### PR TITLE
Extension for MQTTSessionManagerDelegate

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -72,6 +72,15 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
  */
 - (void)sessionManager:(MQTTSessionManager *)sessionManager didChangeState:(MQTTSessionManagerState)newState;
 
+- (void)sessionManager:(MQTTSessionManager *)sessionManager didReceiveErrorEvent:(MQTTSessionManagerState)newState;
+
+/** let user to decide wheather trigger reconnect,sometime when `error.code` == MQTTSessionErrorConnackBadUsernameOrPassword | MQTTSessionErrorConnackServeUnavailable,reconnect is unnecessary.
+ @param sessionManager the instance of MQTTSessionManager whose state changed
+ @param error 
+ */
+- (BOOL)sessionManager:(MQTTSessionManager *)sessionManager didTriggerDelayedReconnectWithError:(NSError *)error;
+
+
 @end
 
 /** SessionManager handles the MQTT session for your application

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -391,9 +391,17 @@
         case MQTTSessionEventProtocolError:
         case MQTTSessionEventConnectionRefused:
         case MQTTSessionEventConnectionError:
-            [self triggerDelayedReconnect];
+            
             self.lastErrorCode = error;
             [self updateState:MQTTSessionManagerStateError];
+            
+            if([self.delegate respondsToSelector:@selector(sessionManager:didTriggerDelayedReconnectWithError:)] && ![self.delegate sessionManager:self didTriggerDelayedReconnectWithError:error]){
+                //do nothing
+            }else {
+                [self triggerDelayedReconnect];
+            }
+            
+            
             break;
 
         default:


### PR DESCRIPTION
let user to decide wheather trigger reconnect,sometime when `error.code` == MQTTSessionErrorConnackBadUsernameOrPassword | MQTTSessionErrorConnackServeUnavailable,reconnect is unnecessary.