### PR TITLE
Introduced new  property 'url' in MQTTWebsocketTransport to accept custom url.  

### DIFF
--- a/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.h
+++ b/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.h
@@ -20,6 +20,11 @@
 */
 @property (strong, nonatomic) NSString *host;
 
+/** url an NSString containing the websocketurl
+ * defaults to @""
+ */
+@property (strong, nonatomic) NSString *url;
+
 /** port an unsigned 32 bit integer containing the IP port number to connect to
  * defaults to 80
  */

--- a/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.h
+++ b/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.h
@@ -20,10 +20,10 @@
 */
 @property (strong, nonatomic) NSString *host;
 
-/** url an NSString containing the websocketurl
- * defaults to @""
+/** url an NSURL containing the presigned URL
+ * defaults to nil
  */
-@property (strong, nonatomic) NSString *url;
+@property (strong, nonatomic) NSURL *url;
 
 /** port an unsigned 32 bit integer containing the IP port number to connect to
  * defaults to 80

--- a/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.m
+++ b/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.m
@@ -19,11 +19,13 @@
 @synthesize delegate;
 @dynamic host;
 @dynamic port;
+@dynamic url;
 
 - (instancetype)init {
     self = [super init];
     self.host = @"localhost";
     self.port = 80;
+    self.url = @"";
     self.path = @"/mqtt";
     self.tls = false;
     self.allowUntrustedCertificates = false;
@@ -34,8 +36,15 @@
 - (void)open {
     DDLogVerbose(@"[MQTTWebsocketTransport] open");
     self.state = MQTTTransportOpening;
+    NSMutableURLRequest *urlRequest = nil;
     
-    NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[self endpointURL]];
+    if ([self.url length] == 0) {
+        urlRequest = [NSMutableURLRequest requestWithURL:[self endpointURL]];
+    } else {
+        NSURL *url = [NSURL URLWithString: self.url];
+        urlRequest = [NSMutableURLRequest requestWithURL:url];
+    }
+    
     urlRequest.SR_SSLPinnedCertificates = self.pinnedCertificates;
     NSArray <NSString *> *protocols = @[@"mqtt"];
     

--- a/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.m
+++ b/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.m
@@ -25,7 +25,7 @@
     self = [super init];
     self.host = @"localhost";
     self.port = 80;
-    self.url = @"";
+    self.url = nil;
     self.path = @"/mqtt";
     self.tls = false;
     self.allowUntrustedCertificates = false;
@@ -36,15 +36,8 @@
 - (void)open {
     DDLogVerbose(@"[MQTTWebsocketTransport] open");
     self.state = MQTTTransportOpening;
-    NSMutableURLRequest *urlRequest = nil;
     
-    if ([self.url length] == 0) {
-        urlRequest = [NSMutableURLRequest requestWithURL:[self endpointURL]];
-    } else {
-        NSURL *url = [NSURL URLWithString: self.url];
-        urlRequest = [NSMutableURLRequest requestWithURL:url];
-    }
-    
+    NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[self endpointURL]];
     urlRequest.SR_SSLPinnedCertificates = self.pinnedCertificates;
     NSArray <NSString *> *protocols = @[@"mqtt"];
     
@@ -57,6 +50,9 @@
 }
 
 - (NSURL*) endpointURL {
+    if(self.url != nil) {
+        return self.url;
+    }
     NSString *protocol = (self.tls) ? @"wss" : @"ws";
     NSString *portString = (self.port == 0) ? @"" : [NSString stringWithFormat:@":%d",(unsigned int)self.port];
     NSString *path = self.path;


### PR DESCRIPTION
Inject `URL` in `MQTTWebsocketTransport`. 

AWS IoT gives self signed URLs. Using the `url` property, user can set the url property directly instead of using `MQTTWebsocketTransport` method `endpointURL` framing it for you using port, tls, etc.  