### PR TITLE
1. resolve decode message callback problem when receive a message bef…

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.h
+++ b/MQTTClient/MQTTClient/MQTTSession.h
@@ -85,6 +85,13 @@ typedef NS_ENUM(NSInteger, MQTTSessionError) {
 
 @optional
 
+
+/**
+ gets called when a effectiveKeepAlive execute
+ @param session 
+ */
+- (void)handleKeepAliveEvent:(MQTTSession *)session;
+
 /** gets called when a new message was received
  @param session the MQTTSession reporting the new message
  @param data the data received, might be zero length

--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -604,6 +604,9 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
 - (void)keepAlive {
     DDLogVerbose(@"[MQTTSession] keepAlive %@ @%.0f", self.clientId, [[NSDate date] timeIntervalSince1970]);
     (void)[self encode:[MQTTMessage pingreqMessage]];
+    if([self.delegate respondsToSelector:@selector(handleKeepAliveEvent:)]) {
+        [self.delegate handleKeepAliveEvent:self];
+    }
 }
 
 - (void)checkDup {
@@ -1596,9 +1599,9 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
 
 - (void)mqttTransportDidClose:(id<MQTTTransport>)mqttTransport {
     DDLogVerbose(@"[MQTTSession] mqttTransport mqttTransportDidClose");
-
-    [self error:MQTTSessionEventConnectionClosedByBroker error:nil];
-
+    dispatch_async(self.queue, ^{
+        [self error:MQTTSessionEventConnectionClosedByBroker error:nil];
+    });
 }
 
 - (void)mqttTransportDidOpen:(id<MQTTTransport>)mqttTransport {


### PR DESCRIPTION

1. resolve decode message callback problem when receive a message before shut down broker 2.provide a delegate method to the outside when keepAlive event execute

about issue:

#496 