### PR TITLE
fix @import issue

### DIFF
--- a/MQTTClient/MQTTClient/MQTTLog.h
+++ b/MQTTClient/MQTTClient/MQTTLog.h
@@ -6,7 +6,11 @@
 //  Copyright © 2016-2017 Christoph Krey. All rights reserved.
 //
 
-@import Foundation;
+#if __has_feature(modules)
+    @import Foundation;
+#else
+    #import <Foundation/Foundation.h>
+#endif
 
 #ifdef LUMBERJACK
 


### PR DESCRIPTION
Hi,

After I upgraded pod version to 0.15.0 from 0.14.0, compiler told me error as below.

```
Use of '@import' when C++ modules are disabled, consider using -fmodules and -fcxx-modules
```

And I figured out that the 0.15.0-release makes the `MQTTLog.h` public which explicitly imports the `MQTTLog.h` into my Objective-C++ source file. And @import break it because modules are disabled in C++ related target.

Let's solve this problem through the clang macro to avoid @import in Objective-C++.