### PR TITLE
Hiding SocketRocket from public headers

### DIFF
--- a/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.h
+++ b/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.h
@@ -8,12 +8,11 @@
 
 #import <Foundation/Foundation.h>
 #import "MQTTTransport.h"
-#import <SocketRocket/SRWebSocket.h>
 
 /** MQTTCFSocketTransport
  * implements an MQTTTransport on top of Websockets (SocketRocket)
  */
-@interface MQTTWebsocketTransport : MQTTTransport <MQTTTransport, SRWebSocketDelegate>
+@interface MQTTWebsocketTransport : MQTTTransport <MQTTTransport>
 
 /** host an NSString containing the hostName or IP address of the host to connect to
  * defaults to @"localhost"

--- a/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.m
+++ b/MQTTClient/MQTTClient/MQTTWebsocketTransport/MQTTWebsocketTransport.m
@@ -7,10 +7,10 @@
 //
 
 #import "MQTTWebsocketTransport.h"
-
+#import <SocketRocket/SRWebSocket.h>
 #import "../MQTTLog.h"
 
-@interface MQTTWebsocketTransport()
+@interface MQTTWebsocketTransport() <SRWebSocketDelegate>
 @property (strong, nonatomic) SRWebSocket *websocket;
 @end
 


### PR DESCRIPTION
We are making an attempt to integrate the MQTT-Client-Framework into a Kotlin-Native library. Unfortunately that breaks because of the SocketRocket reference on the public headers of your library. 