### PR TITLE
[bugfix] remove SecCertificateRef that will cause tls handshake failed

### DIFF
--- a/MQTTClient/MQTTClient/MQTTCFSocketTransport.m
+++ b/MQTTClient/MQTTClient/MQTTCFSocketTransport.m
@@ -230,7 +230,7 @@
         return nil;
     }
     
-    NSArray *clientCerts = @[(__bridge id)identityRef, (__bridge id)cert];
+    NSArray *clientCerts = @[(__bridge id)identityRef];
     return clientCerts;
 }
 


### PR DESCRIPTION
Before deleting the 'cert' code, the package info  of client for exchange  had two certificates which were same with each other. The screenshot is below:
![before-1](https://user-images.githubusercontent.com/3340420/68521579-7b6d2580-02dd-11ea-9190-951f48fed8d8.png)
![before-2](https://user-images.githubusercontent.com/3340420/68521591-90e24f80-02dd-11ea-976e-0381089b963e.png)
After deleting that, everything was OK!
![after-1](https://user-images.githubusercontent.com/3340420/68521607-ae171e00-02dd-11ea-8cdd-ccfb9d0289d5.png)
![after-2](https://user-images.githubusercontent.com/3340420/68521608-b2dbd200-02dd-11ea-9bef-2df0c4e4f04b.png)

The SecIdentityRef contains a SecCertificateRef, so we do not add another SecCertificateRef again!
